### PR TITLE
Fix incorrect command arguments for RothC model

### DIFF
--- a/docs/DevelopmentSetup/visual_studio_win_example.rst
+++ b/docs/DevelopmentSetup/visual_studio_win_example.rst
@@ -156,7 +156,7 @@ These arguments will point at the right configuration files for RothC. Please fo
   * Command Arguments:
   ::
 
-      --config config\point_example.json --config config\debug\libs.base.win.json --logging_config logging.debug_on.conf
+      --config config\point_rothc_example.json --config config\debug\libs.base_rothc.win.json --logging_config logging.debug_on.conf
 
   * Working Directory: ``$(SolutionDir)..\..\Run_Env``
 


### PR DESCRIPTION
The command arguments in the RothC section were wrong and actually, they are the command arguments for the test module.
Corrected them to the appropriate RothC command arguments.
We may also need to move the screenshot to the test module section.