### PR TITLE
Remove explicit CMake URL from prerequisites section

### DIFF
--- a/docs/prerequisites/cmake.rst
+++ b/docs/prerequisites/cmake.rst
@@ -5,4 +5,4 @@ Cmake Installation
 
 CMake is required to build the FLINT from its source code on Windows. CMake is an open-source family of tools designed to build, test and package software.
 
-* Please download and install Cmake from https://github.com/Kitware/CMake/releases/download/v3.15.2/cmake-3.15.2-win64-x64.msi
+* Please download and install the latest binary distribution of CMake for your platform from: https://cmake.org/download/


### PR DESCRIPTION
## Description

This PR is a proposal to make changes to the existing documentation to remove the download link in [Prerequisites/CMake.rst](https://github.com/moja-global/moja_global_docs/blob/master/docs/prerequisites/cmake.rst) that links to a specific CMake version. This is replaced by an URL to the CMake download page so the reader can download the latest version available from the website. For further details and motivation please read: #63 

Fixes #63 

## Type of change
- [x] This change requires a documentation update

## How Has This Been Tested?

N/A

## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

@chicken-biryani @shubhamkarande13 @HarshCasper, could one of you review this please? Thanks!

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
