### PR TITLE
Setup moja global documentation style guide + Add accessibility docs for technical writers

### DIFF
--- a/docs/DocumentationStyleGuide/accessibility.rst
+++ b/docs/DocumentationStyleGuide/accessibility.rst
@@ -1,0 +1,100 @@
+Accessibility
+=============
+
+The moja global community strives towards accessibility in our software
+products and even in the documentation. Through accessibility, we strive
+for successful access to information and resources among people who
+might find it challenging to access them otherwise. We aim to bring
+contributors with limited ability to the forefront of our community to
+have them contribute and access our documentation easily.
+
+The general guidelines for creating accessible documentation pieces are:
+
+-  Maintain consistency across the documentation. Both in style and
+   visuals by employing a fixed hierarchy.
+-  Avoid language or word usage that is potentially biased for a
+   group of people.
+-  Focus on the audience that you are writing for and follow a
+   conversation style of documentation.
+-  Define acronyms, abbreviations, prerequisites initially and never
+   assume the technical competency of the reader.
+-  Use alternative text for multimedia elements wherever possible, and
+   be conscious of the usage of visual elements.
+
+Image accessibility
+-------------------
+
+-  Validate that the images, diagrams, graphs, icons possess a
+   meaningful alternative-text description for a meaningful equivalent.
+-  Use alternative text to describe what the image, digraph, graph or
+   icon does, rather than what it looks like.
+-  All images, diagrams, graphs, icons should contain a caption that should
+   be self-explanatory.
+-  Prefer the usage of SVGs over JPEGs and PNGs. SVGs scale on zooming
+   and provide better context to the readers.
+-  Don’t use images of text, terminal outputs, code samples and other
+   information that can be displayed as text. Always transcribe text or
+   terminal outputs as code blocks.
+
+Text accessibility
+------------------
+
+-  Follow a content hierarchy defined by the content strategy or the
+   documentation plan for the project.
+-  Use Heading-1 only once in the entire content piece. Use Heading-2
+   and Heading-3 for all the sub-headings (#, ##, ### in Markdown).
+-  Headings should be correctly nested to indicate their relative
+   significance in the documentation piece.
+-  Avoid Camel-Case, inconsistent formatting and unnecessary
+   capitalization of text.
+-  Use a table of contents to provide a quick reference to the content.
+-  Always break down your documentation piece into short paragraphs that
+   are easy to consume in chunks and pieces.
+
+UI accessibility
+----------------
+
+-  Avoid documenting instructions and steps that rely on sensory
+   characteristics of the UI and instead rely on what it is supposed to
+   do.
+-  Document the information that is presented in visual colours, in text
+   format as well.
+-  Avoid directional indicators, like above, below, top, while
+   documenting User Interface Navigation.
+-  Provide necessary feedback to designers and engineers on
+   accessibility issues.
+
+Links accessibility
+-------------------
+
+-  Use meaningful link texts with proper Uniform Resource Locator (URL)
+   slugs. Include meaningful keywords in the URL slug and be short,
+   descriptive and functional. For example, if your documentation piece
+   talks about CMake installation, you can use the slug
+   ``cmake-installation/``. Remove numbers, punctuation and duplications
+   while making a URL slug.
+-  Add an indicator, if a link redirects to an external website and
+   opens on another tab, with a text or an icon.
+-  If a link downloads an external file, mention the file type, its
+   standard purpose and the necessary prerequisites.
+-  Don’t use conventional verbs like *here*, *click on this link*, *read
+   this* which betrays the needful necessary to the user before clicking
+   anything.
+-  Use a tool like `broken-link-checker`_ to check for broken links on
+   your documentation piece.
+
+Multimedia accessibility
+------------------------
+
+-  Provide access to captions, transcripts or descriptions for audio and
+   video content.
+-  Avoid low-quality GIFs to display processes and workflows and instead
+   rely on text and high-quality images.
+-  Use proper colour combinations and contrast ratios, with a minimum
+   ratio of 4.5:1.
+-  Avoid auto-playing media and provide as much context as possible
+   before a user clicks on any multimedia element.
+-  Use a Screen Reader to verify your documentation piece before
+   publishing it anywhere.
+
+.. _broken-link-checker: https://www.npmjs.com/package/broken-link-checker

--- a/docs/DocumentationStyleGuide/index.rst
+++ b/docs/DocumentationStyleGuide/index.rst
@@ -43,7 +43,7 @@ our products and services.
 We use Markdown and reStructured documentation to document our products
 and services. Markdown is a markup language that allows us to write
 formatted text. We use `GitHub flavoured Markdown`_, `MDX`_ and
-`reStructuredText`_ majorly among our version-control projects. We use
+`reStructuredText`_ among our version-control projects. We use
 `Google Docs`_ and `HackMD`_ to collaborate internally and share
 feedback among the documentation development teams before pushing it to
 GitHub.
@@ -58,3 +58,10 @@ community to help you out.
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _Google Docs: https://www.google.com/docs/about/
 .. _HackMD: https://hackmd.io/
+
+Contents:
+
+.. toctree::
+  :maxdepth: 1
+
+  accessibility

--- a/docs/DocumentationStyleGuide/index.rst
+++ b/docs/DocumentationStyleGuide/index.rst
@@ -1,0 +1,60 @@
+Moja global documentation style guide
+=====================================
+
+The moja global style guide specifies rules and standards to create
+developer and end-user documentation across the moja global projects.
+The style guide aims for simplicity and flexibility while documenting
+the length and breadth of the technical and user-facing details that
+concerns the overall documentation development in moja global. The
+primary objective of the style guide is to help the documentation
+writers and information developers maintain the style and consistency
+across all our projects while facilitating uniformity.
+
+Purpose
+-------
+
+Moja global’s style guide serves the following purpose for our
+contributors and end-users:
+
+-  Our style guide covers specific areas around grammatical, syntactical
+   and content format. The rules and guidelines are not strict but
+   informative.
+-  The primary purpose of the style guide isn’t to enforce decisions of
+   being right or wrong. It’s more about finding compatibility among
+   existing documentation pieces and maintaining a standard.
+-  The style guide is flexible and open to changes. The documentation
+   context is another factor to shape the information.
+-  The foremost importance is given to the clarity and the meaning of
+   the documentation piece. The style guide should be just trusted as a
+   standard to keep the documentation consistent.
+-  Every documentation piece is developed with accessibility and
+   inclusivity. We at moja global serve a global audience of developers,
+   writers, scientists and users. We strive to make our project
+   accessible for all.
+
+.. _tools--technologies:
+
+Tools & Technologies
+--------------------
+
+At moja global, we use a variety of tools and technologies to document
+our products and services.
+
+We use Markdown and reStructured documentation to document our products
+and services. Markdown is a markup language that allows us to write
+formatted text. We use `GitHub flavoured Markdown`_, `MDX`_ and
+`reStructuredText`_ majorly among our version-control projects. We use
+`Google Docs`_ and `HackMD`_ to collaborate internally and share
+feedback among the documentation development teams before pushing it to
+GitHub.
+
+These tools are easy to learn and pick up. You can refer to open-source
+tutorials and guides on the same to pick them up fairly quickly. If you
+have any questions or doubts, please ask your peer or your mentor in the
+community to help you out.
+
+.. _GitHub flavoured Markdown: https://en.wikipedia.org/wiki/Markdown#GitHub_Flavored_Markdown
+.. _MDX: https://mdxjs.com/
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _Google Docs: https://www.google.com/docs/about/
+.. _HackMD: https://hackmd.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,5 +25,6 @@ maintainers for other reasons, please drop a mail at info@moja.global.
    GCBMDevelopmentSetup/index
    contributing/index
    DeveloperWorkflow/index
+   DocumentationStyleGuide/index
    faq
    contact


### PR DESCRIPTION
## Description

This PR:

- Sets the moja global documentation style guide and the basic premise
- Adds documentation for technical writers to write accessible docs

## Preview

- Style guide index: https://moja-global-documentation--95.org.readthedocs.build/en/95/DocumentationStyleGuide/index.html
- Accessibility docs: https://moja-global-documentation--95.org.readthedocs.build/en/95/DocumentationStyleGuide/accessibility.html