### PR TITLE
Standardise on cmd for windows terminal

### DIFF
--- a/docs/DevelopmentSetup/docker_installation_example.rst
+++ b/docs/DevelopmentSetup/docker_installation_example.rst
@@ -31,7 +31,7 @@ Building the docker
    Building the FLINT.example image using Docker
 
 Commands to run using docker - stock result written to screen and
-results files create (./Run_Env/*.csv): :
+results files create (./Run_Env/*.csv):
 
 ::
 
@@ -43,7 +43,7 @@ results files create (./Run_Env/*.csv): :
    # For Windows
    docker run --rm -v %cd%/Run_Env:/usr/local/run_env -ti moja/flint.example:bionic bash -c "cd /usr/local/run_env/; moja.cli --config config/point_example.json --config config/libs.base.simple.json --logging_config logging.debug_on.conf"
 
-For the RothC example, you may run this command:-
+For the RothC example, you may run this command:
 
 ::
 
@@ -61,7 +61,7 @@ For the RothC example, you may run this command:-
    Running the examples using Docker
 
 Commands to run moja from within the docker - stock result written to
-screen and results files create (./Run_Env/*.csv): :
+screen and results files create (./Run_Env/*.csv):
 
 ::
 
@@ -71,7 +71,7 @@ screen and results files create (./Run_Env/*.csv): :
    # For Windows
    docker run --rm -v %cd%/Run_Env:/usr/local/run_env -ti moja/flint.example:bionic bash
 
-Then inside the running container: :
+Then inside the running container:
 
 ::
 
@@ -79,7 +79,7 @@ Then inside the running container: :
    moja.cli --config config/point_example.json --config config/libs.base.simple.json --logging_config logging.debug_on.conf
    moja.cli --config config/point_rothc_example.json --config config/libs.base_rothc.simple.json --logging_config logging.debug_on.conf
 
-The Output files created are visible in the below screenshot:-
+The Output files created are visible in the below screenshot:
 
 .. figure:: ../images/installation_docker/step2b_docker.png
    :alt: Running the moja.cli

--- a/docs/DevelopmentSetup/git_and_github_guide.rst
+++ b/docs/DevelopmentSetup/git_and_github_guide.rst
@@ -3,16 +3,16 @@
 Git and Github guide
 ====================
 
-This guide is to help new contributors setup git, github and navigate
+This guide is to help new contributors set up Git, GitHub and navigate
 their way through making contributions to moja global repositories. It
-covers the entire process of contributing right from installing git to
+covers the entire process of contributing right from installing Git to
 opening pull requests.
 
 Setup this project using Git
 ----------------------------
 
 Before setting up this project using Git make sure you have installed
-and configured git by following the instructions `here`_.
+and configured Git by following the instructions `here`_.
 
 Fork and Clone this project
 ---------------------------
@@ -21,35 +21,35 @@ Fork and Clone this project
    upper left corner, there is a **Fork** button. Please click on it to
    create a fork/copy of the repository on your profile.
 
-\* In the terminal screen, clone this repo by running the command where
-``your-username`` represents your Github username. :
+- In a terminal, clone this repo by running the command where ``your-username``
+  represents your Github username.
 
 ::
 
    git clone https://github.com/<your-username>/FLINT/
 
-\* Enter into the newly created project folder by running the command :
+- Enter into the newly created project folder by running this command.
 
 ::
 
    cd FLINT
 
-\* Configure upstream for the fork so that git can sync work from the
-upstream if it is updated by running the command :
+- Configure upstream for the fork so that Git can sync work from the
+  upstream if it is updated by running this command.
 
 ::
 
    git remote add upstream https://github.com/moja-global/FLINT/
 
-\* Check if upstream is configured by running the command and check if
-upstream is shown or not. :
+- Check if upstream is configured by running the command and check if
+  upstream is shown or not.
 
 ::
 
    git remote -v
 
-\* Make sure you've checked out to the ``develop`` Branch to be updated, it consists of all the latest changes 
-for the FLINT Installation. :
+- Make sure you've checked out the ``develop`` branch to be updated. It consists of all the latest changes
+  for the FLINT Installation.
 
 ::
 
@@ -85,8 +85,8 @@ issue and label the issue as ``in progress``. Some additional notes:
 Make a contribution
 -------------------
 
-This section will show you step-by-step how to make a contribution to
-FLINT using git.
+This section shows you step-by-step how to make a contribution to
+FLINT using Git.
 
 -  FLINT stable branch is **develop**. Releases are scheduled
    periodically when codebase is production-ready and the ``develop``

--- a/docs/DevelopmentSetup/visual_studio_example.rst
+++ b/docs/DevelopmentSetup/visual_studio_example.rst
@@ -36,8 +36,6 @@ To build the project the cmake and C++ extensions will be required.
 These have been specified in the ``devcontainer.json`` file. To build
 the library use Cmake Configure, Build and Install.
 
-:
-
 ::
 
    "extensions": [
@@ -55,8 +53,6 @@ should be ready to run/debug one of the samples.
 inside the dev-container, so there is a new version of the library
 configs for VS Code. These commands will work from the terminal in the
 running container after cmake has been successful.
-
-:
 
 ::
 

--- a/docs/DevelopmentSetup/visual_studio_win_example.rst
+++ b/docs/DevelopmentSetup/visual_studio_win_example.rst
@@ -22,7 +22,7 @@ the Installation.
 Using vcpkg to install required libraries
 -----------------------------------------
 
-Start a command shell in the Vcpkg repository folder (that you had
+Start ``cmd`` in the Vcpkg repository folder (that you had
 cloned earlier) and use the following commands:
 
 ::
@@ -34,29 +34,23 @@ cloned earlier) and use the following commands:
    vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows fmt:x64-windows libpqxx:x64-windows
 
 .. figure:: ../images/installation_vs2019_flint.example/Step1b.png
-   :alt: Installing required packages using vcpkg in Command Prompt
+   :alt: Install required packages using vcpkg in ``cmd``
    :align: center
    :width: 600px
 
-   Installing required packages using vcpkg in Command Prompt
+   Install required packages using vcpkg in ``cmd``.
 
 Building the project
 --------------------
 
-Launch the Windows Powershell and run the following commands:
+Launch ``cmd`` and run the following commands:
 
 ::
 
    # Create a build folder under the Source folder
-   mkdir -p Source\build
-   cd Source\build
-
-.. figure:: ../images/installation_vs2019_flint.example/Step2.png
-   :alt: Creating a build Directory for Cloned FLINT.example repo
-   :align: center
-   :width: 600px
-
-   Creating a build Directory for Cloned FLINT.example repo
+   cd Source
+   mkdir build
+   cd build
 
 Now depending on which type of simulation you want to execute, you may
 run one of the following generate commands:
@@ -188,7 +182,7 @@ the correct configuration -
    -  Command:
       ``C:\Development\moja-global\FLINT\Source\build\bin\Debug\moja.cli.exe``
 
-   \* Command Arguments: :
+   -  Command Arguments:
 
    ::
 
@@ -196,7 +190,7 @@ the correct configuration -
 
    -  Working Directory: ``$(SolutionDir)..\..\Run_Env``
 
-   \* Environment: :
+   -  Environment: :
 
    ::
 

--- a/docs/DevelopmentSetup/windows_installation.rst
+++ b/docs/DevelopmentSetup/windows_installation.rst
@@ -6,9 +6,9 @@ Windows Installation
 This section guides first-time contributors through installing FLINT
 development environment.
 
-Before proceeding further, make sure you have setup the project using
+Before proceeding further, make sure you have set up the project using
 Git by following our guide `Git and GitHub Guide`_. Also make sure you
-have the following prerequisites setup.
+have the following prerequisites set up.
 
 Prerequisites
 -------------
@@ -24,7 +24,7 @@ the Installation.
 Using vcpkg to install required libraries
 -----------------------------------------
 
-Start a command shell in the Vcpkg repository folder (that you had
+Start ``cmd`` in the Vcpkg repository folder (that you had
 cloned earlier) and use the following commands:
 
 ::
@@ -56,7 +56,7 @@ Setting up the FLINT development environment
 
    Develop Branch of FLINT
 
--  Start command shell in the FLINT folder of your system and run
+-  Start ``cmd`` in the FLINT folder of your system and run
    command:
 
 ::
@@ -67,7 +67,7 @@ Setting up the FLINT development environment
 Using CMake to build the project
 --------------------------------
 
-Start a command shell in your FLINT core
+Start ``cmd`` in your FLINT core
 repository folder. Now use the following commands to create the Visual
 Studio solution:
 
@@ -87,7 +87,7 @@ Studio solution:
 
 .. note::
 
-   All paths used below with ``C:\Development\moja-global`` will need to
+   All paths used below with ``C:\Development\moja-global`` need to
    be modified to match your system build location of the moja project.
 
 .. _Git and GitHub Guide: git_and_github_guide.html
@@ -99,7 +99,8 @@ Studio solution:
 Building the FLINT
 ===================
 
-Run a command shell and navigate to the build folder.
+Run ``cmd`` and navigate to the build folder.
+
 - Type ``moja.sln`` in the command prompt. Visual studio is launched.
 - After Visual Studio has loaded completely, move to the Solution Explorer in the top right, expand the **CMakePredefinedTargets** and select **ALL_BUILD**.
 - Right click on **ALL_BUILD** and click on **Build** in the menu.

--- a/docs/GCBMDevelopmentSetup/prerequisites.rst
+++ b/docs/GCBMDevelopmentSetup/prerequisites.rst
@@ -26,7 +26,7 @@ Existing Python Installation
 -  Locate your existing Python 3.7 installation (where python.exe is
    located). If you have both 32 and 64-bit versions installed (common
    with ArcGIS), find the path to the 64-bit version.
--  From a command prompt in the ``python_3_installer`` directory, type:
+-  From a terminal in the ``python_3_installer`` directory, type:
    ``install_modules_only <python path>``
 
 .. figure:: ../images/installation_gcbm/image2.png
@@ -42,7 +42,7 @@ New Python Installation
 -  Verify that you have no existing Python 3.7 installation – it is not
    usually possible to install the same version in two different
    locations.
--  From a command prompt in the ``python_3_installer`` directory, type:
+-  From a terminal in the ``python_3_installer`` directory, type:
    ``install_python [optional install path]``
 
 .. figure:: ../images/installation_gcbm/image4.png

--- a/docs/prerequisites/docker.rst
+++ b/docs/prerequisites/docker.rst
@@ -3,37 +3,37 @@
 Setup Docker (for Linux based variants only)
 ============================================
 
-In-order to setup FLINT by using docker containers, please follow the
-instructions below based on your Linux Distro. If your Linux distro is
+In order to set up FLINT by using docker containers, please follow the
+instructions below based on your Linux distro. If your Linux distro is
 not listed below, please checkout the `Docker official installation
 guides`_ for more information:
 
 -  **Install on CentOS**
 
    In order to setup the latest version of Docker on CentOS, checkout
-   the official `Docker installation guide for CentOS`_ .
+   the official `Docker installation guide for CentOS`_.
 
 -  **Install on Fedora**
 
    In order to setup the latest version of Docker on Fedora, checkout
-   the official `Docker installation guide for Fedora`_ .
+   the official `Docker installation guide for Fedora`_.
 
 -  **Install on Debian**
 
    In order to setup the latest version of Docker on Debian, checkout
-   the official `Docker installation guide for Debian`_ .
+   the official `Docker installation guide for Debian`_.
 
 -  **Install on Ubuntu**
 
    In order to setup the latest version of Docker on Ubuntu, checkout
-   the official `Docker installation guide for Ubuntu`_ .
+   the official `Docker installation guide for Ubuntu`_.
 
 Test Docker version
 -------------------
 
 Verify if the docker installation is successful by running the following
-command. If the following command does not return the version of the
-docker, your installation has been unsuccessful, please try again. :
+command. If the following command does not return the docker version,
+your installation has been unsuccessful, please try again.
 
 ::
 

--- a/docs/prerequisites/git.rst
+++ b/docs/prerequisites/git.rst
@@ -3,8 +3,8 @@
 Setup Git
 =========
 
-If you already have a Git client and Github account, please skip this
-section. Otherwise, keep on reading!
+If you already have a Git client and Github account, please `skip this
+section <https://docs.moja.global/en/latest/prerequisites/cmake.html>`__. Otherwise, keep on reading!
 
 Install and Configure Git
 -------------------------

--- a/docs/prerequisites/vcpkg.rst
+++ b/docs/prerequisites/vcpkg.rst
@@ -15,9 +15,7 @@ To build the libraries please follow the following steps:
 
 * Clone the Vcpkg repository in the moja-global folder from `here <https://github.com/moja-global/vcpkg>`__.
 
-* Start a command shell in the vcpkg repository folder and run the following commands:
-
-Note: The process may take one to two hours, depending on the specifications of your system.
+* Start ``cmd`` in the vcpkg repository folder and run the following commands:
 
 ::
 
@@ -26,3 +24,6 @@ Note: The process may take one to two hours, depending on the specifications of 
 
     # install packages
     vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows fmt:x64-windows libpqxx:x64-windows
+
+  
+Note: The process may take one to two hours, depending on the specifications of your system.

--- a/docs/prerequisites/visual_studio.rst
+++ b/docs/prerequisites/visual_studio.rst
@@ -29,7 +29,7 @@ After launching the Visual Studio installer:
 -  Click on **Install**
 
 .. figure:: ../images/visual_studio/install_page.PNG
-   :alt: Install Section of Visual Studio 
+   :alt: Install Section of Visual Studio
    :width: 600
    :align: center
 
@@ -41,14 +41,14 @@ After the installation is complete:
 -  Create a folder inside ``C`` Drive and name it ``Development``.
 -  Inside the ``Development`` folder create a folder and name it
    ``moja-global``
--  Open the ``moja-global`` folder in the command prompt.
+-  Using ``cmd``, open the ``moja-global`` folder.
 
 .. figure:: ../images/visual_studio/command_prompt.PNG
    :alt: Command Prompt of Windows
    :width: 600
    :align: center
 
-   Folder Path In Command Prompt
+   Folder Path In `cmd`
 
 
 For Visual Studio 2017


### PR DESCRIPTION
# Description

Resolves issue #62. To make the documentation more consistent these proposed changes standardise on one terminal for the reader to use with windows. This will benefit readers who are not from a developer background as they may not know the distinction between cmd and powershell and that each terminal will require different commands to achieve the same purpose.

