### PR TITLE
CI: Stop linkcheck from running during a push event

### DIFF
--- a/.github/workflows/checklink.yml
+++ b/.github/workflows/checklink.yml
@@ -1,8 +1,6 @@
 name: Linkcheck
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:


### PR DESCRIPTION
# Description

This PR:
 Removes push event from triggering the linkcheck action.

Thanks for opening the Pull Request for moja global. Happy contributing ✨

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
