### PR TITLE
docs: fix instruction to build the flint example docker image

### DIFF
--- a/docs/DevelopmentSetup/docker_installation_example.rst
+++ b/docs/DevelopmentSetup/docker_installation_example.rst
@@ -12,16 +12,13 @@ Prerequisites
 
 -  `Docker`_
 
-Building the docker
--------------------
+Building the docker image
+-------------------------
 
 ::
 
    # from repository root folder
-   cd Docker
    docker build --build-arg NUM_CPU=8 -t moja/flint.example:bionic .
-
--  Return to top level folder with ``cd ..``
 
 .. figure:: ../images/installation_docker/step1_docker.png
    :alt: Building the FLINT.example image using Docker
@@ -31,7 +28,7 @@ Building the docker
    Building the FLINT.example image using Docker
 
 Commands to run using docker - stock result written to screen and
-results files create (./Run_Env/*.csv):
+results files create (./Run_Env/\*.csv):
 
 ::
 
@@ -61,7 +58,7 @@ For the RothC example, you may run this command:
    Running the examples using Docker
 
 Commands to run moja from within the docker - stock result written to
-screen and results files create (./Run_Env/*.csv):
+screen and results files create (./Run_Env/\*.csv):
 
 ::
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- [X] Issue reference: #171 
- [X] Peer reviewer: @HarshCasper 
- [X] Preview Links: https://docs.moja.global/en/latest/DevelopmentSetup/docker_installation_example.html
- [X] Explain the changes: The instruction to build the flint example docker image is updated due to the restructuring of the repository


Thanks for opening the Pull Request for moja global. Happy contributing ✨

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
