### PR TITLE
feat: pre-commit hook to correct spellings using codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo : https://github.com/codespell-project/codespell 
+    rev : v2.1.0 
+    hooks:
+    -   id: codespell
+        name: codespell
+        entry: codespell --write
+        language: python
+        files : '.rst'

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ make linkcheck
 ```
 
 You can now look for the broken links, if any, inside `_build/linkcheck/output` .
+#### Setup the pre-commit hook 
+
+In order to ensure that the documentation is free from unforced spelling errors, a [pre-commit](https://pre-commit.com/) hook has been used. On executing `git commit`, [codespell](https://github.com/codespell-project/codespell) checks for spelling errors.
+
+Steps to install pre-commit : 
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+If spelling errors are detected, codespell automatically corrects the spelling. It is required to execute `git add` to stage the changes made.
 
 ## How to Get Involved?
 


### PR DESCRIPTION
# Description

This PR adds a pre-commit hook to correct the spellings of commonly used words. Words related to the technical domain are not modified by codespeller

- [X] Issue reference: #190 
- [X] Peer reviewer: @HarshCasper @chicken-biryani @shubhamkarande13 
- [X] Explain the changes: A `pre-commit` hook has been introduced, such that each time the command `git commit` is run, commonly used spellings are checked for correctness in `rst` files only
- [X] Dependency changes: The `pre-commit` hooks requires the installation of the `pre-commit` in the local repository
- [X] Documentation update: The steps to install `pre-commit` and setup the environment are updated in the README

The following is an error reported by codespeller 

The word `merge` is misspelled as `mege`, in the file https://docs.moja.global/en/master/Guidelines/DeveloperWorkflow/bots_and_integrations.html

![image](https://user-images.githubusercontent.com/53875297/171618447-ade4e760-2d88-4d30-a35c-13157aea2ada.png)

The changes are corrected and staged as shown below
![image](https://user-images.githubusercontent.com/53875297/171619343-5044ec9a-45e2-49c6-80a2-0a19c3cb5622.png)


Thanks for opening the Pull Request for moja global. Happy contributing ✨

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
