### PR TITLE
ci: add codespell on pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+name: pre-commit 
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ pre-commit install
 
 If spelling errors are detected, codespell automatically corrects the spelling. It is required to execute `git add` to stage the changes made.
 
+The job `spell-check` in the Github Action named `pre-commit` is used to run the spell check on CI. A failed Github Action indicates the presence of spelling errors. The contributors should correct the spelling errors and commit the changes
+
 ## How to Get Involved?
 
 moja global welcomes a wide range of contributions as explained in the [Contributing guide](https://community.moja.global/community/contributing) and in the [About moja global page](https://community.moja.global/docs/about-moja-global).


### PR DESCRIPTION
# Description

This PR adds a Github Action to run the spell-checker codespell

- [X] Issue reference: #196 

On encountering spelling errors in `.rst` files, this is the result of the GitHub Action

![image](https://user-images.githubusercontent.com/53875297/175786776-50ac1e9f-2664-4a7a-ab9d-f5d57f1bfe1a.png)


Thanks for opening the Pull Request for moja global. Happy contributing ✨

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
